### PR TITLE
gr-uhd: fixed argparse note for uhd_fft --update-rate

### DIFF
--- a/gr-uhd/apps/uhd_fft
+++ b/gr-uhd/apps/uhd_fft
@@ -473,7 +473,7 @@ def setup_argparser():
     group.add_argument("--avg-alpha", type=float, default=None,
         help="Specify FFT average alpha (overrides --fft-average)")
     group.add_argument("--update-rate", dest="update_rate", type=eng_arg.eng_float, default=eng_notation.num_to_str(.1),
-        help="Set GUI widget update rate")
+        help="Set GUI widget update period in seconds")
     group.add_argument("--phase-relations", action="store_true",
         help="Plot relative phases between multiple channels")
     return parser


### PR DESCRIPTION
The argument --update-rate is really a period, not a rate, from what I can tell.  Instead of changing the variable name, I just edited the argparse note to mention that the units are in seconds.